### PR TITLE
Ignore AGENTS.md in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ specs/
 
 # Serena
 .serena/
+
+# Agents guide
+AGENTS.md


### PR DESCRIPTION
## Summary
- add AGENTS.md to .gitignore so the generated guide stays local

## Testing
- not applicable