### PR TITLE
Strip internal console metadata from reporter output

### DIFF
--- a/.changeset/trim-console-metadata.md
+++ b/.changeset/trim-console-metadata.md
@@ -2,4 +2,5 @@
 "vitest-llm-reporter": patch
 ---
 
-Strip internal console metadata before emitting results so downstream consumers avoid extra context while dedupe stats remain intact.
+-Keep full-fidelity console metadata in internal state while trimming the default output view for LLM consumption.
+-Expose `outputView.console.includeTestId` and `outputView.console.includeTimestampMs` flags so downstream tooling can surface those fields when needed.

--- a/.changeset/trim-console-metadata.md
+++ b/.changeset/trim-console-metadata.md
@@ -1,0 +1,5 @@
+---
+"vitest-llm-reporter": patch
+---
+
+Strip internal console metadata before emitting results so downstream consumers avoid extra context while dedupe stats remain intact.

--- a/src/events/EventOrchestrator.ts
+++ b/src/events/EventOrchestrator.ts
@@ -466,31 +466,10 @@ export class EventOrchestrator {
 
     for (const failure of results.failed) {
       applyMetadata(failure.consoleEvents)
-      this.stripInternalConsoleFields(failure.consoleEvents)
     }
 
     for (const success of results.successLogs) {
       applyMetadata(success.consoleEvents)
-      this.stripInternalConsoleFields(success.consoleEvents)
-    }
-  }
-
-  /**
-   * Removes internal-only fields before output serialization
-   */
-  private stripInternalConsoleFields(events?: ConsoleEvent[]): void {
-    if (!events || events.length === 0) {
-      return
-    }
-
-    for (const event of events) {
-      if ('testId' in event) {
-        delete event.testId
-      }
-
-      if ('timestampMs' in event) {
-        delete event.timestampMs
-      }
     }
   }
 

--- a/src/output/types.ts
+++ b/src/output/types.ts
@@ -1,6 +1,10 @@
 import type { TestResult, TestFailure, TestSuccessLog } from '../types/schema.js'
 import type { SerializedError } from 'vitest'
-import type { TruncationConfig, EnvironmentMetadataConfig } from '../types/reporter.js'
+import type {
+  TruncationConfig,
+  EnvironmentMetadataConfig,
+  OutputViewConfig
+} from '../types/reporter.js'
 
 /**
  * Output builder configuration
@@ -24,6 +28,8 @@ export interface OutputBuilderConfig {
   rootDir?: string
   /** Options controlling environment metadata included in the summary */
   environmentMetadata?: EnvironmentMetadataConfig
+  /** Output view configuration */
+  view?: OutputViewConfig
 }
 
 /**

--- a/src/reporter/reporter.console-capture.test.ts
+++ b/src/reporter/reporter.console-capture.test.ts
@@ -168,6 +168,8 @@ describe('LLMReporter Console Capture Integration', () => {
       level: 'info',
       message: 'Informational message'
     })
+    expect(successLog?.consoleEvents?.every((event) => event.testId === undefined)).toBe(true)
+    expect(successLog?.consoleEvents?.every((event) => event.timestampMs === undefined)).toBe(true)
     expect(successLog?.suppressed).toMatchObject({ totalLines: 2, suppressedLines: 0 })
   })
 

--- a/src/reporter/reporter.console-direct.test.ts
+++ b/src/reporter/reporter.console-direct.test.ts
@@ -81,6 +81,52 @@ describe('LLMReporter Console Capture - Direct Test', () => {
     expect(failure?.consoleEvents?.every((event) => event.timestampMs === undefined)).toBe(true)
   })
 
+  it('allows including internal console metadata via outputView config', async () => {
+    reporter = new LLMReporter({
+      verbose: false,
+      captureConsoleOnFailure: true,
+      outputView: {
+        console: {
+          includeTestId: true,
+          includeTimestampMs: true
+        }
+      }
+    })
+    reporter.onTestRunStart([])
+
+    const testId = 'test-console-view'
+    const mockTestCase = {
+      id: testId,
+      type: 'test',
+      name: 'test with console metadata',
+      result: {
+        state: 'fail',
+        error: new Error('Test failed')
+      },
+      fileRelative: '/test/file.ts',
+      location: { start: { line: 10 }, end: { line: 20 } }
+    } as unknown as TestCase
+
+    reporter.onUserConsoleLog({
+      content: 'metadata log',
+      type: 'stdout',
+      taskId: testId,
+      time: Date.now(),
+      size: 12
+    })
+
+    reporter.onTestCaseResult(mockTestCase)
+
+    await reporter.onTestRunEnd([], [], 'failed')
+
+    const output = reporter.getOutput()
+    const failure = output?.failures?.[0]
+    const event = failure?.consoleEvents?.[0]
+
+    expect(event?.testId).toBe(testId)
+    expect(typeof event?.timestampMs).toBe('number')
+  })
+
   it('should not capture console for passing tests', () => {
     const mockTestCase = {
       id: 'test-passing',

--- a/src/reporter/reporter.console-direct.test.ts
+++ b/src/reporter/reporter.console-direct.test.ts
@@ -77,6 +77,8 @@ describe('LLMReporter Console Capture - Direct Test', () => {
 
     expect(logEvents.some((e) => e.message === 'Test log message')).toBe(true)
     expect(errorEvents.some((e) => e.message === 'Test error message')).toBe(true)
+    expect(failure?.consoleEvents?.every((event) => event.testId === undefined)).toBe(true)
+    expect(failure?.consoleEvents?.every((event) => event.timestampMs === undefined)).toBe(true)
   })
 
   it('should not capture console for passing tests', () => {

--- a/src/reporter/reporter.ts
+++ b/src/reporter/reporter.ts
@@ -15,7 +15,8 @@ import type {
   LLMReporterConfig,
   StdioConfig,
   TruncationConfig,
-  EnvironmentMetadataConfig
+  EnvironmentMetadataConfig,
+  OutputViewConfig
 } from '../types/reporter.js'
 import type { OrchestratorConfig } from '../events/types.js'
 import type { LLMReporterOutput, TestError } from '../types/schema.js'
@@ -85,6 +86,7 @@ interface ResolvedLLMReporterConfig
       }
     | undefined
   environmentMetadata: EnvironmentMetadataConfig | undefined
+  outputView: OutputViewConfig | undefined
 }
 
 // Import new components
@@ -251,7 +253,8 @@ export class LLMReporter implements Reporter {
       stdio: stdioConfig,
       warnWhenConsoleBlocked: config.warnWhenConsoleBlocked ?? true,
       fallbackToStderrOnBlocked: config.fallbackToStderrOnBlocked ?? true,
-      environmentMetadata: config.environmentMetadata ?? undefined
+      environmentMetadata: config.environmentMetadata ?? undefined,
+      outputView: config.outputView ?? undefined
     }
 
     this.stdioFilter = new StdioFilterEvaluator(
@@ -280,7 +283,8 @@ export class LLMReporter implements Reporter {
       includeAbsolutePaths: this.config.includeAbsolutePaths,
       rootDir: process.cwd(),
       truncation: this.config.truncation,
-      environmentMetadata: this.config.environmentMetadata
+      environmentMetadata: this.config.environmentMetadata,
+      view: this.config.outputView
     })
     this.outputWriter = new OutputWriter()
 
@@ -374,6 +378,16 @@ export class LLMReporter implements Reporter {
         if (value !== undefined && typeof value !== 'boolean') {
           throw new Error(`environmentMetadata.${key.toString()} must be a boolean`)
         }
+      }
+    }
+
+    if (config.outputView?.console) {
+      const { includeTestId, includeTimestampMs } = config.outputView.console
+      if (includeTestId !== undefined && typeof includeTestId !== 'boolean') {
+        throw new Error('outputView.console.includeTestId must be a boolean')
+      }
+      if (includeTimestampMs !== undefined && typeof includeTimestampMs !== 'boolean') {
+        throw new Error('outputView.console.includeTimestampMs must be a boolean')
       }
     }
   }

--- a/src/reporter/reporter.ts
+++ b/src/reporter/reporter.ts
@@ -571,6 +571,11 @@ export class LLMReporter implements Reporter {
       outputBuilderConfig.environmentMetadata = this.config.environmentMetadata
       shouldUpdateOutputBuilder = true
     }
+    if ('outputView' in partialConfig) {
+      // Forward view projection changes to OutputBuilder
+      outputBuilderConfig.view = this.config.outputView
+      shouldUpdateOutputBuilder = true
+    }
 
     if (shouldUpdateOutputBuilder) {
       this.outputBuilder.updateConfig(outputBuilderConfig)

--- a/src/types/reporter.ts
+++ b/src/types/reporter.ts
@@ -28,6 +28,24 @@ export interface EnvironmentMetadataConfig {
 }
 
 /**
+ * Controls which console event fields are surfaced in reporter output
+ */
+export interface ConsoleOutputViewConfig {
+  /** Include the originating testId for each console event (default: false) */
+  includeTestId?: boolean
+  /** Include the timestamp in milliseconds relative to test start (default: false) */
+  includeTimestampMs?: boolean
+}
+
+/**
+ * Output view configuration
+ */
+export interface OutputViewConfig {
+  /** Console event visibility controls */
+  console?: ConsoleOutputViewConfig
+}
+
+/**
  * Predicate type used for stdout/stderr filtering
  */
 export type StdioFilter = RegExp | ((line: string) => boolean)
@@ -117,6 +135,8 @@ export interface LLMReporterConfig {
       }
   /** Configure which environment metadata fields are included in the summary */
   environmentMetadata?: EnvironmentMetadataConfig
+  /** Configure how test results are projected into the final output */
+  outputView?: OutputViewConfig
 }
 
 /**

--- a/tests/integration/deduplication-finalization.test.ts
+++ b/tests/integration/deduplication-finalization.test.ts
@@ -76,8 +76,8 @@ describe('Integration: Deduplication finalization', () => {
     expect(metadata).toBeDefined()
     expect(metadata?.count).toBe(2)
     expect(metadata?.sources).toEqual(expect.arrayContaining(['test-1', 'test-2']))
-    expect(finalizedFailure.consoleEvents?.[0]?.testId).toBeUndefined()
-    expect(finalizedFailure.consoleEvents?.[0]?.timestampMs).toBeUndefined()
+    expect(finalizedFailure.consoleEvents?.[0]?.testId).toBe('test-1')
+    expect(typeof finalizedFailure.consoleEvents?.[0]?.timestampMs).toBe('number')
   })
 
   it('forwards Vitest log timestamps to console capture', () => {

--- a/tests/integration/deduplication-finalization.test.ts
+++ b/tests/integration/deduplication-finalization.test.ts
@@ -76,6 +76,8 @@ describe('Integration: Deduplication finalization', () => {
     expect(metadata).toBeDefined()
     expect(metadata?.count).toBe(2)
     expect(metadata?.sources).toEqual(expect.arrayContaining(['test-1', 'test-2']))
+    expect(finalizedFailure.consoleEvents?.[0]?.testId).toBeUndefined()
+    expect(finalizedFailure.consoleEvents?.[0]?.timestampMs).toBeUndefined()
   })
 
   it('forwards Vitest log timestamps to console capture', () => {

--- a/tests/integration/output-view-toggle.test.ts
+++ b/tests/integration/output-view-toggle.test.ts
@@ -62,4 +62,3 @@ describe('Integration: outputView runtime updates', () => {
     expect(ev2?.timestamp).toBe(123)
   })
 })
-

--- a/tests/integration/output-view-toggle.test.ts
+++ b/tests/integration/output-view-toggle.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { LLMReporter } from '../../src/reporter/reporter.js'
+import type { BuildOptions } from '../../src/output/types.js'
+import type { TestSuccessLog, ConsoleEvent } from '../../src/types/schema.js'
+
+describe('Integration: outputView runtime updates', () => {
+  it('should propagate outputView (console) changes to OutputBuilder at runtime', () => {
+    const reporter = new LLMReporter({})
+
+    // Prepare a minimal success log with console events containing fields gated by the view
+    const consoleEvent: ConsoleEvent = {
+      level: 'log',
+      message: 'hello',
+      testId: 'test-1',
+      timestampMs: 123,
+      timestamp: 123,
+      args: ['a']
+    }
+
+    const successLog: TestSuccessLog = {
+      test: 'sample test',
+      fileRelative: 'sample.test.ts',
+      startLine: 1,
+      endLine: 1,
+      status: 'passed',
+      consoleEvents: [consoleEvent]
+    }
+
+    const buildOpts: BuildOptions = {
+      testResults: {
+        passed: [],
+        failed: [],
+        skipped: [],
+        successLogs: [successLog]
+      },
+      duration: 10
+    }
+
+    // Access the builder for controlled build (testing propagation behavior)
+    const builder = (reporter as any).outputBuilder as {
+      build: (opts: BuildOptions) => { successLogs?: Array<{ consoleEvents?: ConsoleEvent[] }> }
+    }
+
+    // Initial build should NOT include testId/timestamp by default (projection false)
+    const out1 = builder.build(buildOpts)
+    const ev1 = out1.successLogs?.[0].consoleEvents?.[0]
+    expect(ev1).toBeDefined()
+    expect(ev1?.testId).toBeUndefined()
+    expect(ev1?.timestampMs).toBeUndefined()
+    expect(ev1?.timestamp).toBeUndefined()
+
+    // Update reporter config to include these fields
+    reporter.updateConfig({
+      outputView: { console: { includeTestId: true, includeTimestampMs: true } }
+    })
+
+    const out2 = builder.build(buildOpts)
+    const ev2 = out2.successLogs?.[0].consoleEvents?.[0]
+    expect(ev2).toBeDefined()
+    expect(ev2?.testId).toBe('test-1')
+    expect(ev2?.timestampMs).toBe(123)
+    expect(ev2?.timestamp).toBe(123)
+  })
+})
+


### PR DESCRIPTION
## Summary
- keep internal console events high fidelity and have `OutputBuilder` project the default LLM view
- add `outputView.console` toggles so callers can include `testId`/`timestampMs` in emitted logs when needed
- refresh reporter/integration coverage for both the default and metadata-enabled views

## Testing
- npm run test
