### PR TITLE
Fix TestEndResolver fixture to satisfy lint rule

### DIFF
--- a/src/extraction/TestEndResolver.test.ts
+++ b/src/extraction/TestEndResolver.test.ts
@@ -62,11 +62,15 @@ test('expr', () => expect(true).toBe(true))
     const file = path.join(dir, 'chained.test.ts')
     const content = `import { test } from 'vitest'
 
-test.concurrent.only('chained', async () => {
+test.concurrent.__ONLY__('chained', async () => {
   await Promise.resolve()
   return 'done'
 })
 `
+      // Maintain a `.only` call in the generated fixture without tripping the vitest
+      // lint rule that forbids focused tests in our source. The resolver still
+      // receives the literal `.only` syntax once this placeholder is replaced.
+      .replace('__ONLY__', 'only')
     writeFileSync(file, content)
 
     try {


### PR DESCRIPTION
## Summary
- adjust the TestEndResolver chained test fixture so that the generated code still exercises `.only` without violating the Vitest lint rule

## Testing
- npm run lint
- npm run test -- TestEndResolver

------
https://chatgpt.com/codex/tasks/task_e_68e3da821d888331b8f9038918d57ccd