### PR TITLE
docs: clarify Vitest version support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # vitest-llm-reporter
 
+## Unreleased
+
+### Documentation
+
+- Clarify that Vitest 4 is the supported baseline, note the best-effort status of Vitest 3, and update public docs accordingly. (Fixes #114)
+
 ## 1.2.0
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ Vitest reporter that generates structured JSON output optimized for LLM parsing.
 ## Requirements
 
 - Node.js 18+ (uses native `structuredClone`)
-- Vitest 3.0+
+- Vitest 4.0+
+
+### Version Support
+
+Vitest 4 is the officially supported baseline and the only version exercised in CI. Earlier Vitest 3.x releases may continue to function, but that combination is no longer validated. Treat Vitest 3 compatibility as best-effort and plan to upgrade when possible.
 
 ## Installation
 

--- a/docs/TESTED_CONFIGURATIONS.md
+++ b/docs/TESTED_CONFIGURATIONS.md
@@ -2,6 +2,8 @@
 
 This document lists all configuration scenarios that are tested through our integration matrix E2E tests. These scenarios represent real-world usage patterns and ensure the reporter works correctly across different configuration combinations.
 
+> **Vitest versions:** The matrix runs on Vitest 4.x, which is the officially supported baseline. Earlier Vitest 3.x releases may keep working, but we do not validate them in CI.
+
 ## Test Scenarios
 
 The following scenarios are automatically tested in `tests/e2e/config-matrix.test.ts`:


### PR DESCRIPTION
- Update README requirements to call out Vitest 4 as the supported baseline and mark Vitest 3 as best-effort.\n- Note the Vitest version coverage in docs/TESTED_CONFIGURATIONS.md so the test matrix and policy stay aligned.\n- Add a changelog stub capturing the support policy shift.\n\nFixes #114