### PR TITLE
fix: segment-aware root boundary checks for path classification

### DIFF
--- a/src/utils/paths.test.ts
+++ b/src/utils/paths.test.ts
@@ -59,6 +59,12 @@ describe('Path Utilities', () => {
       )
     })
 
+    it('should not convert sibling paths that share only a string prefix', () => {
+      expect(toRepoRelative('/home/project-e2e/file.ts', '/home/project')).toBe(
+        '/home/project-e2e/file.ts'
+      )
+    })
+
     it('should handle empty or invalid input', () => {
       expect(toRepoRelative('', '/home/project')).toBe('')
       expect(toRepoRelative('/home/project/test.ts', '')).toBe('/home/project/test.ts')
@@ -95,6 +101,12 @@ describe('Path Utilities', () => {
 
     it('should handle external files', () => {
       const result = classify('/tmp/external.ts', '/home/project')
+      expect(result.inProject).toBe(false)
+      expect(result.inNodeModules).toBe(false)
+    })
+
+    it('should not classify sibling prefix paths as in-project', () => {
+      const result = classify('/home/project-e2e/file.ts', '/home/project')
       expect(result.inProject).toBe(false)
       expect(result.inNodeModules).toBe(false)
     })
@@ -159,6 +171,13 @@ describe('Path Utilities', () => {
     it('should handle external paths', () => {
       const result = processFilePath('/tmp/external.ts', '/home/project', false)
       expect(result.fileRelative).toBe('/tmp/external.ts')
+      expect(result.inProject).toBe(false)
+      expect(result.inNodeModules).toBe(false)
+    })
+
+    it('should not convert sibling prefix paths during processing', () => {
+      const result = processFilePath('/home/project-e2e/file.ts', '/home/project', false)
+      expect(result.fileRelative).toBe('/home/project-e2e/file.ts')
       expect(result.inProject).toBe(false)
       expect(result.inNodeModules).toBe(false)
     })


### PR DESCRIPTION
## Summary
- fix `toRepoRelative` and `classify` to use segment-aware root boundary checks instead of raw prefix checks
- prevent sibling paths like `/home/project-e2e/file.ts` from being treated as in-project
- add permanent regression coverage in `src/utils/paths.test.ts` for `toRepoRelative`, `classify`, and `processFilePath`

## Design alignment
- aligned with path-boundary intent in `docs/SECURITY.md` and existing path handling expectations in `src/utils/path-validator.ts`
- no dedicated issue-specific design doc found in-repo; this change follows the repository's current path-safety model

## Validation
- `npm test -- src/utils/paths.test.ts`
- `npm test -- src/reporter/reporter.paths.test.ts`
- `npm test`
- `npm run lint`
- `npm run type-check`

Fixes #143
