### PR TITLE
Fix node_modules substring false positives in path classification

### DIFF
--- a/src/extraction/ContextExtractor.test.ts
+++ b/src/extraction/ContextExtractor.test.ts
@@ -256,6 +256,26 @@ Line 3`
       expect(frames[1].fileRelative).toContain('node_modules')
     })
 
+    it('should preserve user files with node_modules in filename when filtering', () => {
+      const customExtractor = new ContextExtractor({
+        rootDir: '/home/project',
+        filterNodeModules: true
+      })
+
+      const stack = `Error: Test error
+  at helper (/home/project/src/node_modules-helper.ts:10:5)
+  at /home/project/node_modules/vitest/dist/runner.js:500:10`
+
+      const frames = customExtractor.parseStackTrace(stack)
+
+      expect(frames).toHaveLength(1)
+      expect(frames[0]).toMatchObject({
+        fileRelative: 'src/node_modules-helper.ts',
+        inProject: true,
+        inNodeModules: false
+      })
+    })
+
     it('should handle V8 style stack traces exclusively', () => {
       const stack = `Error: Test failed
   at testFunction (/src/test.ts:10:15)

--- a/src/utils/paths.test.ts
+++ b/src/utils/paths.test.ts
@@ -99,6 +99,12 @@ describe('Path Utilities', () => {
       expect(result.inNodeModules).toBe(true)
     })
 
+    it('should not treat node_modules substrings as dependency paths', () => {
+      const result = classify('/home/project/src/node_modules-helper.ts', '/home/project')
+      expect(result.inProject).toBe(true)
+      expect(result.inNodeModules).toBe(false)
+    })
+
     it('should handle external files', () => {
       const result = classify('/tmp/external.ts', '/home/project')
       expect(result.inProject).toBe(false)

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -29,6 +29,10 @@ function isWithinRootBoundary(path: string, root: string): boolean {
   return path === root || path.startsWith(`${root}/`)
 }
 
+function hasNodeModulesSegment(path: string): boolean {
+  return /(^|\/)node_modules(\/|$)/.test(path)
+}
+
 /**
  * Normalizes file URLs or file system paths to absolute paths.
  * Handles file:// URLs and regular paths.
@@ -125,9 +129,8 @@ export function classify(
   const normalizedPath = normalizePathForComparison(absPath)
   const normalizedRoot = normalizePathForComparison(rootDir)
 
-  // Check if path is in node_modules (cross-platform)
-  const inNodeModules =
-    normalizedPath.includes('/node_modules/') || normalizedPath.includes('node_modules')
+  // Check if path contains node_modules as a full path segment (cross-platform)
+  const inNodeModules = hasNodeModulesSegment(normalizedPath)
 
   // Check if path is in project (under root and not in node_modules)
   const inProject = isWithinRootBoundary(normalizedPath, normalizedRoot) && !inNodeModules


### PR DESCRIPTION
## Summary
- switch `classify()` to segment-aware `node_modules` detection (`(^|/)node_modules(/|$)`)
- preserve user files like `src/node_modules-helper.ts` as project code
- add regression coverage in `src/utils/paths.test.ts` and `src/extraction/ContextExtractor.test.ts`

## Design alignment
- aligns with README `filterNodeModules` contract: only actual `node_modules` stack frames are omitted
- no dedicated ADR/design doc for this path rule exists in `docs/`; README behavior and issue acceptance criteria were used as source of truth

## Testing
- `npm test -- src/utils/paths.test.ts src/extraction/ContextExtractor.test.ts`

Fixes #144
