### PR TITLE
fix: return false for malformed encoded file paths

### DIFF
--- a/src/utils/sanitization.test.ts
+++ b/src/utils/sanitization.test.ts
@@ -308,6 +308,13 @@ describe('Sanitization Utilities', () => {
         expect(validateFilePath('')).toBe(false)
       })
 
+      it('should return false for malformed percent-encoding without throwing', () => {
+        const malformedEncodedPath = '%E0%A4%A'
+
+        expect(() => validateFilePath(malformedEncodedPath)).not.toThrow()
+        expect(validateFilePath(malformedEncodedPath)).toBe(false)
+      })
+
       it('should reject non-string inputs', () => {
         expect(validateFilePath(null as any)).toBe(false)
         expect(validateFilePath(undefined as any)).toBe(false)

--- a/src/utils/sanitization.ts
+++ b/src/utils/sanitization.ts
@@ -144,7 +144,13 @@ function validateFilePathInternal(
     return fail('Path contains disallowed protocol')
   }
 
-  const decodedPath = decodeURIComponent(filePath)
+  let decodedPath = filePath
+  try {
+    decodedPath = decodeURIComponent(filePath)
+  } catch {
+    return fail('Path contains malformed percent-encoding')
+  }
+
   if (decodedPath !== filePath) {
     record('decodedPath', decodedPath)
     if (decodedPath.includes('..') || decodedPath.includes('\0')) {


### PR DESCRIPTION
## Summary
- guard `decodeURIComponent` in `validateFilePath` with `try/catch`
- return `false` when percent-encoding is malformed instead of throwing
- add a regression test for `%E0%A4%A` in `src/utils/sanitization.test.ts`

## Validation
- `npm test -- src/utils/sanitization.test.ts`

Fixes #145
